### PR TITLE
Add Rental Property Business Licence to Business Ecosystem documentation

### DIFF
--- a/docs/governance/business/index.md
+++ b/docs/governance/business/index.md
@@ -15,16 +15,20 @@ The Business Ecosystem provides digital credentials and documentation for busine
 ### Digital Business Card
 The [BC Digital Business Card](./digital-business-card-v1.md) (DBC) credential is a verifiable credential (VC) issued to individuals to enable them to prove to other parties (“verifiers”) that the individual is affiliated with a business registered or incorporated at BC Registries. Additionally, the credential includes verifiable information about both the individual and the business.
 
+### Rental Property Business Licence
+The [Rental Property Business Licence](./rental-property-business-licence.md) credential is a verifiable credential (VC) issued to individuals or authorized representatives of businesses to prove that they hold a valid City of Vancouver rental business licence.
 
 ## Implementation Status
 
 | Credential | Status | Network |
 |------------|---------|----------|
 | Digital Business Card | Production | CANdy Network |
+| Rental Property Business Licence | Production | CANdy Network |
 
 ## Getting Started
 
 - Review the [Digital Business Card documentation](./digital-business-card-v1.md)
+- Review the [Rental Property Business Licence documentation](./rental-property-business-licence.md)
 - Understand the verification and issuance processes
 - Learn about integration options
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -24,6 +24,7 @@ nav:
     - Business Ecosystem:
       - Overview: governance/business/index.md
       - Digital Business Card: governance/business/digital-business-card-v1.md
+      - Rental Property Business Licence: governance/business/rental-property-business-licence.md
     - Person Ecosystem:
       - Overview: governance/person/index.md
       - Person Credential: governance/person/person-cred-doc.md


### PR DESCRIPTION
- Updated mkdocs.yml to include a new section for the Rental Property Business Licence.
- Enhanced the index.md file in the Business Ecosystem to provide details about the Rental Property Business Licence credential, including its purpose and implementation status.
- Added a link to the Rental Property Business Licence documentation for user reference.

This commit improves the documentation structure by integrating the new credential into the existing Business Ecosystem framework.