### PR TITLE
feat: add LTSA property owner credential docs to ToC, update page

### DIFF
--- a/docs/governance/business/index.md
+++ b/docs/governance/business/index.md
@@ -18,17 +18,22 @@ The [BC Digital Business Card](./digital-business-card-v1.md) (DBC) credential i
 ### Rental Property Business Licence
 The [Rental Property Business Licence](./rental-property-business-licence.md) credential is a verifiable credential (VC) issued to individuals or authorized representatives of businesses to prove that they hold a valid City of Vancouver rental business licence.
 
+### Property Owner Credential
+The [Property Owner Credential](./ltsa-property-owner-governance.md) credential is a verifiable credential (VC) issued to individuals registered in BC’s Land Title Register to prove property ownership.
+
 ## Implementation Status
 
 | Credential | Status | Network |
 |------------|---------|----------|
 | Digital Business Card | Production | CANdy Network |
 | Rental Property Business Licence | Production | CANdy Network |
+| Property Owner Credential | Production | CANdy Network |
 
 ## Getting Started
 
 - Review the [Digital Business Card documentation](./digital-business-card-v1.md)
 - Review the [Rental Property Business Licence documentation](./rental-property-business-licence.md)
+- Review the [Property Owner Credential documentation](./ltsa-property-owner-governance.md)
 - Understand the verification and issuance processes
 - Learn about integration options
 

--- a/docs/governance/business/ltsa-property-owner-governance.md
+++ b/docs/governance/business/ltsa-property-owner-governance.md
@@ -103,8 +103,8 @@ The credential uses the [Hyperledger AnonCreds](https://hyperledger.github.io/an
 | **Environment** | **Issuer Name**                        | **Issuer DID**                                                |  
 |-----------------|----------------------------------------|---------------------------------------------------------------|
 | CANdy Dev       | Land Title and Survey Authority of BC  | KKSXjEHUPVNGYHuof1J3xy                                        |
-| CANdy Test      | Land Title and Survey Authority of BC  | TBC                                                           |   
-| CANdy Prod      | Land Title and Survey Authority of BC  | TBC                                                           |    
+| CANdy Test      | Land Title and Survey Authority of BC  | Tm3dXMR3UsSU4X9Ew913Um                                        |   
+| CANdy Prod      | Land Title and Survey Authority of BC  | JqrH76X8ETpUaNx6TTiP4i                                        |    
 
 
 
@@ -112,11 +112,11 @@ The credential uses the [Hyperledger AnonCreds](https://hyperledger.github.io/an
 ### 6.3 Schema
 
 
-| **Environment** | **Ledger**                             | **Schema ID**                                                 |  
-|-----------------|----------------------------------------|---------------------------------------------------------------|
-| CANdy Dev       |  https://candyscan.idlab.org/tx/CANDY_DEV/domain/35671                                      | KKSXjEHUPVNGYHuof1J3xy:2:property-owner:1.1.0                 |
-| CANdy Test      | TBC  | TBC                                    |
-| CANdy Prod      | TBC                                    | TBC                                                           |    
+| **Environment** | **Ledger**                                             | **Schema ID**                                                 |  
+|-----------------|--------------------------------------------------------|---------------------------------------------------------------|
+| CANdy Dev       |  https://candyscan.idlab.org/tx/CANDY_DEV/domain/39372 | KKSXjEHUPVNGYHuof1J3xy:2:property-owner:1.1.0                 |
+| CANdy Test      | TBC                                                    | Tm3dXMR3UsSU4X9Ew913Um:2:property-owner:1.1.0                 |
+| CANdy Prod      | TBC                                                    | JqrH76X8ETpUaNx6TTiP4i:2:property-owner:1.1.0                 |    
 
 
 
@@ -125,7 +125,7 @@ The credential uses the [Hyperledger AnonCreds](https://hyperledger.github.io/an
 
 | **Environment** | **Ledger**                             | **Credential Definition ID**                                  |  **OCA Bundle**                  |
 |-----------------|----------------------------------------|---------------------------------------------------------------|----------------------------------|
-| CANdy Dev       | https://candyscan.idlab.org/tx/CANDY_DEV/domain/35671  | KKSXjEHUPVNGYHuof1J3xy:3:CL:39372:property-owner                                    |    TBC                              |
+| CANdy Dev       | https://candyscan.idlab.org/tx/CANDY_DEV/domain/39383  | KKSXjEHUPVNGYHuof1J3xy:3:CL:39372:property-owner                                    |    TBC                              |
 | CANdy Test      | TBC  								   | TBC                                    |    TBC                              |
 | CANdy Prod      | TBC                                    | TBC                                    |    TBC                              |
 

--- a/docs/governance/business/ltsa-property-owner-governance.md
+++ b/docs/governance/business/ltsa-property-owner-governance.md
@@ -116,7 +116,7 @@ The credential uses the [Hyperledger AnonCreds](https://hyperledger.github.io/an
 | **Environment** | **Ledger**                                             | **Schema ID**                                                 |  
 |-----------------|--------------------------------------------------------|---------------------------------------------------------------|
 | CANdy Dev       | [Property Owner Credential](https://candyscan.idlab.org/tx/CANDY_DEV/domain/39553) | KKSXjEHUPVNGYHuof1J3xy:2:property-owner:1.0.4                 |
-| CANdy Test      | [Property Owner Credential](https://candyscan.idlab.org/tx/CANDY_TEST/domain/1093) | Tm3dXMR3UsSU4X9Ew913Um:2:property-owner:1.0.4                |
+| CANdy Test      | [Property Owner Credential](https://candyscan.idlab.org/tx/CANDY_TEST/domain/1092) | Tm3dXMR3UsSU4X9Ew913Um:2:property-owner:1.0.4                |
 | CANdy Prod      | TBC                                                    |                 |    
 
 
@@ -126,7 +126,7 @@ The credential uses the [Hyperledger AnonCreds](https://hyperledger.github.io/an
 
 | **Environment** | **Ledger**                             | **Credential Definition ID**                                  |  **OCA Bundle**                  |
 |-----------------|----------------------------------------|---------------------------------------------------------------|----------------------------------|
-| CANdy Dev       | [Property Owner Credential](https://candyscan.idlab.org/tx/CANDY_DEV/domain/39553)  | KKSXjEHUPVNGYHuof1J3xy:3:CL:39553:property-owner | TBC                           |
+| CANdy Dev       | [Property Owner Credential](https://candyscan.idlab.org/tx/CANDY_DEV/domain/39554)  | KKSXjEHUPVNGYHuof1J3xy:3:CL:39553:property-owner | TBC                           |
 | CANdy Test      | [Property Owner Credential](https://candyscan.idlab.org/tx/CANDY_TEST/domain/1093)  | Tm3dXMR3UsSU4X9Ew913Um:3:CL:1092:property-owner  | TBC                           |
 | CANdy Prod      | TBC                                    | TBC                                    |    TBC                              |
 

--- a/docs/governance/business/ltsa-property-owner-governance.md
+++ b/docs/governance/business/ltsa-property-owner-governance.md
@@ -8,6 +8,7 @@ This document describes the Land Title and Survey Authority of British Columbia�
 
 | Ver.      | Date        | Notes                |
 | --------- | ----------- | -------------------- |
+|1.1        |2026-03-25   | Updated 5.2, 6.3 and 6.4 |
 | 1.0       |2026-03-09   | Initial Version      |
 
 
@@ -85,7 +86,7 @@ The subject of the Property Owner Credential is the verified registered owner of
 | **Display Name** | **Attribute**   | **Description**                                                |   **Format**   | **Rules & Notes**               | **Examples**          |
 |------------------|-----------------|----------------------------------------------------------------|----------------| --------------------------------|-----------------------|
 | PID              | pid             |   A nine-digit number that uniquely identifies a parcel in the land title register of British Columbia. The registrar assigns PID numbers to parcels for which a title is being entered in the computer register as a registered title.                                                             |     String     | Format: ###-###-### (three groups of three digits separated by dashes)"                          |    012-345-678        | 
-| Property Address | PropertyAddress |  Typically the Civic address of the property or user entered address information at the time a credential is issued                                                              |     String     |        Mandatory                |   Unit 305 – 1234 Main Street, Vancouver, BC                 |
+| Property Address | property_address |  Typically the Civic address of the property or user entered address information at the time a credential is issued                                                              |     String     |        Mandatory                |   Unit 305 – 1234 Main Street, Vancouver, BC                 |
 
 
   
@@ -114,9 +115,9 @@ The credential uses the [Hyperledger AnonCreds](https://hyperledger.github.io/an
 
 | **Environment** | **Ledger**                                             | **Schema ID**                                                 |  
 |-----------------|--------------------------------------------------------|---------------------------------------------------------------|
-| CANdy Dev       |  https://candyscan.idlab.org/tx/CANDY_DEV/domain/39372 | KKSXjEHUPVNGYHuof1J3xy:2:property-owner:1.1.0                 |
-| CANdy Test      | TBC                                                    | Tm3dXMR3UsSU4X9Ew913Um:2:property-owner:1.1.0                 |
-| CANdy Prod      | TBC                                                    | JqrH76X8ETpUaNx6TTiP4i:2:property-owner:1.1.0                 |    
+| CANdy Dev       | [Property Owner Credential](https://candyscan.idlab.org/tx/CANDY_DEV/domain/39553) | KKSXjEHUPVNGYHuof1J3xy:2:property-owner:1.0.4                 |
+| CANdy Test      | [Property Owner Credential](https://candyscan.idlab.org/tx/CANDY_TEST/domain/1093) | Tm3dXMR3UsSU4X9Ew913Um:2:property-owner:1.0.4                |
+| CANdy Prod      | TBC                                                    |                 |    
 
 
 
@@ -125,8 +126,8 @@ The credential uses the [Hyperledger AnonCreds](https://hyperledger.github.io/an
 
 | **Environment** | **Ledger**                             | **Credential Definition ID**                                  |  **OCA Bundle**                  |
 |-----------------|----------------------------------------|---------------------------------------------------------------|----------------------------------|
-| CANdy Dev       | https://candyscan.idlab.org/tx/CANDY_DEV/domain/39383  | KKSXjEHUPVNGYHuof1J3xy:3:CL:39372:property-owner                                    |    TBC                              |
-| CANdy Test      | TBC  								   | TBC                                    |    TBC                              |
+| CANdy Dev       | [Property Owner Credential](https://candyscan.idlab.org/tx/CANDY_DEV/domain/39553)  | KKSXjEHUPVNGYHuof1J3xy:3:CL:39553:property-owner | TBC                           |
+| CANdy Test      | [Property Owner Credential](https://candyscan.idlab.org/tx/CANDY_TEST/domain/1093)  | Tm3dXMR3UsSU4X9Ew913Um:3:CL:1092:property-owner  | TBC                           |
 | CANdy Prod      | TBC                                    | TBC                                    |    TBC                              |
 
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -28,6 +28,7 @@ nav:
       - Overview: governance/business/index.md
       - Digital Business Card: governance/business/digital-business-card-v1.md
       - Rental Property Business Licence: governance/business/rental-property-business-licence.md
+      - Property Owner Credential: governance/business/lts-property-owner-credential.md 
     - Person Ecosystem:
       - Overview: governance/person/index.md
       - Person Credential: governance/person/person-cred-doc.md


### PR DESCRIPTION
Starting a draft PR with the required changes to publish the governance for the `LTSA Property Owner Credential`.

Before merging, the following updates are required:
- Add links to schema, creddef to document
- Add credential definition id for `test` and `prod` once written to the ledger
- Add OCA reference at least for `prod`