### PR TITLE
fix: correct LTSA Property Owner navigation path

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -30,7 +30,7 @@ nav:
           - Overview: governance/business/index.md
           - Digital Business Card: governance/business/digital-business-card-v1.md
           - Rental Property Business Licence: governance/business/rental-property-business-licence.md
-          - Property Owner Credential: governance/business/ltsa-property-owner-credential.md
+          - Property Owner Credential: governance/business/ltsa-property-owner-governance.md
       - Person Ecosystem:
           - Overview: governance/person/index.md
           - Person Credential: governance/person/person-cred-doc.md


### PR DESCRIPTION
Fix: Correct LTSA Property Owner navigation path. The menu item was pointing to ltsa-property-owner-credential.md but the actual file is ltsa-property-owner-governance.md, causing 404 errors.