### PR TITLE
fix: add MSDiLOA to Business Ecosystem nav and index

### DIFF
--- a/docs/governance/business/index.md
+++ b/docs/governance/business/index.md
@@ -21,6 +21,9 @@ The [Rental Property Business Licence](./rental-property-business-licence.md) cr
 ### Property Owner Credential
 The [Property Owner Credential](./ltsa-property-owner-governance.md) credential is a verifiable credential (VC) issued to individuals registered in BC’s Land Title Register to prove property ownership.
 
+### Municipal Services Digital Letter of Authorization (MSDiLOA)
+The [Municipal Services Digital Letter of Authorization](./municipal-services-digital-letter-of-authorization.md) (MSDiLOA) credential is a verifiable credential (VC) issued by a BC municipality to authorize a person to consume municipal services on behalf of another person or business. The first use case covers authorization to apply for a short-term rental business licence.
+
 ## Implementation Status
 
 | Credential | Status | Network |
@@ -28,12 +31,14 @@ The [Property Owner Credential](./ltsa-property-owner-governance.md) credential 
 | Digital Business Card | Production | CANdy Network |
 | Rental Property Business Licence | Production | CANdy Network |
 | Property Owner Credential | Production | CANdy Network |
+| Municipal Services Digital Letter of Authorization (MSDiLOA) | Pilot | CANdy Network |
 
 ## Getting Started
 
 - Review the [Digital Business Card documentation](./digital-business-card-v1.md)
 - Review the [Rental Property Business Licence documentation](./rental-property-business-licence.md)
 - Review the [Property Owner Credential documentation](./ltsa-property-owner-governance.md)
+- Review the [Municipal Services Digital Letter of Authorization documentation](./municipal-services-digital-letter-of-authorization.md)
 - Understand the verification and issuance processes
 - Learn about integration options
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -31,6 +31,7 @@ nav:
           - Digital Business Card: governance/business/digital-business-card-v1.md
           - Rental Property Business Licence: governance/business/rental-property-business-licence.md
           - Property Owner Credential: governance/business/ltsa-property-owner-governance.md
+          - Municipal Services Digital Letter of Authorization: governance/business/municipal-services-digital-letter-of-authorization.md
       - Person Ecosystem:
           - Overview: governance/person/index.md
           - Person Credential: governance/person/person-cred-doc.md


### PR DESCRIPTION
Adds the newly-created MSDiLOA page to the mkdocs nav under Business Ecosystem, and surfaces it on the Business Ecosystem overview page alongside the other credentials (description, status table, getting-started link).