### PR TITLE
fix: update OCA bundle links to match aries-oca-bundles reorganization

### DIFF
--- a/docs/governance/justice/court-services-branch/governance.md
+++ b/docs/governance/justice/court-services-branch/governance.md
@@ -180,7 +180,7 @@ The Transcriber Credential issued to contractors from A2A is mapped as:
 10. A2A Criminal Record Check Expiry Date = criminal_record_expiry_dateint
 
 ### OCA:
-[OCABundles/schema/bcgov-digital-trust/transcriber-contractor/README.md](https://github.com/bcgov/aries-oca-bundles/blob/main/OCABundles/schema/bcgov-digital-trust/transcriber-contractor/README.md)
+[OCABundles/schema/bcgov-digital-trust/JAG/transcriber-contractor/README.md](https://github.com/bcgov/aries-oca-bundles/blob/main/OCABundles/schema/bcgov-digital-trust/JAG/transcriber-contractor/README.md)
 
 ## 2.7. Information Trust Requirements
 

--- a/docs/governance/mining/bc-mines-act-permit/1.1.1/governance.md
+++ b/docs/governance/mining/bc-mines-act-permit/1.1.1/governance.md
@@ -177,7 +177,7 @@ This schema definition follows [the AnonCreds specification](https://wiki.hyperl
 | [BCovrin Test](http://test.bcovrin.vonx.io/)                       | S7S2wzcF2giKuwxdeLBk69:2:bc-mines-act-permit:1.1.1 | Test - November 16, 2023       |
 
 ### 2.6.4 Overlays Capture Architecture (OCA) Bundle
-[B.C. Mines Act Permit Credential](https://github.com/bcgov/aries-oca-bundles/tree/main/OCABundles/schema/bcgov-digital-trust/mines-act-permit)
+[B.C. Mines Act Permit Credential](https://github.com/bcgov/aries-oca-bundles/tree/main/OCABundles/schema/bcgov-digital-trust/MDS/mines-act-permit)
 
 ## 2.7. Information Trust Requirements
 Not applicable.


### PR DESCRIPTION
## Summary

Patches two DITP governance links that point to OCA bundle paths being moved by [bcgov/aries-oca-bundles#209](https://github.com/bcgov/aries-oca-bundles/pull/209).

- `docs/governance/justice/court-services-branch/governance.md` — `transcriber-contractor` moved under `JAG/`
- `docs/governance/mining/bc-mines-act-permit/1.1.1/governance.md` — `mines-act-permit` moved under `MDS/`

## DO NOT MERGE — depends on aries-oca-bundles#209

This PR should not be merged until [bcgov/aries-oca-bundles#209](https://github.com/bcgov/aries-oca-bundles/pull/209) is merged into `main` in the bundles repo. The new paths (`OCABundles/schema/bcgov-digital-trust/JAG/transcriber-contractor/` and `OCABundles/schema/bcgov-digital-trust/MDS/mines-act-permit/`) must exist before this PR resolves — otherwise the links will 404.

Suggested merge order:
1. Merge [bcgov/aries-oca-bundles#209](https://github.com/bcgov/aries-oca-bundles/pull/209) first.
2. Verify the new `JAG/` and `MDS/` folders exist on `main` in the bundles repo.
3. Then merge this PR.

## Notes

- Other DITP governance docs that link to OCA bundles (LTSA, LSBC, CityOfVancouver) are not affected by PR #209 — those paths are unchanged.
- No content changes; only URL paths updated.
